### PR TITLE
Support ontology writer

### DIFF
--- a/src/main/java/tr/com/srdc/ontmalizer/XSD2OWLMapper.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/XSD2OWLMapper.java
@@ -3,6 +3,7 @@ package tr.com.srdc.ontmalizer;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -748,6 +749,15 @@ public class XSD2OWLMapper {
 	 */
 	public void writeOntology(OutputStream out, String format) {
 		ontology.write(out, format, null);
+	}
+	
+	/**
+	 * @param out
+	 * @param format
+	 * - Output format may be one of these values; "RDF/XML","RDF/XML-ABBREV","N-TRIPLE","N3".
+	 */
+	public void writeOntology(Writer writer, String format) {
+		ontology.write(writer, format, null);
 	}
 	
 	private RDFList getFacetList(SimpleTypeRestriction facets, XSRestrictionSimpleType restriction) {

--- a/src/test/java/tr/com/srdc/ontmalizer/test/XSD2OWLTest.java
+++ b/src/test/java/tr/com/srdc/ontmalizer/test/XSD2OWLTest.java
@@ -5,6 +5,8 @@ package tr.com.srdc.ontmalizer.test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.Writer;
 
 import org.junit.Test;
 
@@ -79,6 +81,27 @@ public class XSD2OWLTest {
 			ont = new FileOutputStream(f);
 			mapping.writeOntology(ont, "N3");
 			ont.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@Test
+	public void writerTest() {
+
+		// This part converts XML schema to OWL ontology.
+		XSD2OWLMapper mapping = new XSD2OWLMapper(new File("src/test/resources/test/test.xsd"));
+		mapping.setObjectPropPrefix("");
+		mapping.setDataTypePropPrefix("");
+		mapping.convertXSD2OWL();
+
+		// This part prints the ontology to the specified file.
+		try {
+			File f = new File("src/test/resources/output/test.n3");
+			f.getParentFile().mkdirs();
+			Writer w = new FileWriter(f);
+			mapping.writeOntology(w, "N3");
+			w.close();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Added support for Writer (next to OutputStream) to write the ontologies.
The underlying org.apache.jena.ontology.Ontmodel already supported this.