### PR TITLE
Make Structured RDF types instead of Anonymous types

### DIFF
--- a/src/main/java/tr/com/srdc/ontmalizer/XML2OWLMapper.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/XML2OWLMapper.java
@@ -199,11 +199,7 @@ public class XML2OWLMapper {
                 newNsMap.put(key,  nsmap.get(key));
             }
         }
-        
         model.setNsPrefixes(newNsMap);
-        
-        
-        
         this.opprefix = mapping.getObjectPropPrefix();
         this.dtpprefix = mapping.getDataTypePropPrefix();
     }
@@ -226,16 +222,13 @@ public class XML2OWLMapper {
      */
     public void convertXML2OWL() {
         Element root = document.getDocumentElement();
-        
 
         // Set namespace and its prefix if it is not set before.
         if (NS == null) {
             setNSPrefix(root);
         }
 
-        
         OntClass rootType = xsdMapper.rootTypeMap.get(NS + root.getLocalName());
-        
         if (rootType == null) {
             // add relevant details to NPE
             LOGGER.error("NS={}, rootlocalname={}", NS, root.getLocalName());
@@ -267,7 +260,6 @@ public class XML2OWLMapper {
         NamedNodeMap attributes = node.getAttributes();
         LOGGER.debug("There are {} attributes for this node", attributes.getLength());
         for (int i = 0, length = attributes.getLength(); i < length; i++) {
-        
             Node attributeNode = attributes.item(i);
             LOGGER.debug("Node: {}, attribute Node: {}, attribute local name: {}, subject: {}, subjectType:{}", node, attributeNode, attributeNode.getLocalName(), subject, subjectType);
             TypedResource atObjType = findObjectType(subjectType, attributeNode.getLocalName(), attributeNode, true);
@@ -292,11 +284,8 @@ public class XML2OWLMapper {
         Resource object = null;
 
         if (node.getNodeType() == Node.ELEMENT_NODE) {
-            
             LOGGER.debug("Node {} is an element node. Local name: {}, Node name: {}, Node namespace: {},", node, node.getLocalName(), node.getNodeName(), node.getNamespaceURI());
-            
             objectType = findObjectType(subjectType, node.getLocalName(), node, false);
-            
             if (objectType != null) {
             	LOGGER.debug("Object type: {} objectType.resource: {}", objectType, objectType.getResource());
                 /**
@@ -329,11 +318,7 @@ public class XML2OWLMapper {
                         LOGGER.warn("Object type has null resource! ObjectType: {}", objectType);
                     }else {
                         if (!count.containsKey(objectType.getResource().getURI())){
-                            // wrong URI because different namespace from root object, try using the node's namespace
                             LOGGER.warn("Haven't seen resource with URI '{}' before. Known URIs: {}", objectType.getResource().getURI(), count.keySet());
-                            //objectType = findResourceType(node.getNamespaceURI() + '#' + node.getLocalName());
-                            //LOGGER.debug("New object type: {}, new object type is datatype: {}, new resource: {}, ", objectType, objectType.isDatatype(), objectType.getResource());
-                            //count.put(resource.getURI(), 0);
                             if (!count.containsKey(objectType.getResource().getURI())){
                                 throw new NullPointerException("Count doesn't contain URI: " + objectType.getResource().getURI() 
                                 +"\nfor resource: " + objectType.getResource() + "\n for objectType: " + objectType);
@@ -347,11 +332,8 @@ public class XML2OWLMapper {
                                 + "_"
                                 + count.get(objectType.getResource().getURI()), objectType.getResource());
                         LOGGER.trace("objectType: {}, objectType.getResource(): {}", objectType, objectType.getResource());                    
-                        
                         count.put(objectType.getResource().getURI(), count.get(objectType.getResource().getURI()) + 1);
-    
                         Property prop = model.createProperty(NS + NamingUtil.createPropertyName(opprefix, node.getLocalName()));
-    
                         subject.addProperty(prop, object);
                   }
                 } else if (node.getFirstChild() != null && node.getFirstChild().getNodeValue() != null) {
@@ -402,10 +384,8 @@ public class XML2OWLMapper {
         
         OntClass temp;
         if (!isNodeAttribute && !root.getNameSpace().equals(node.getNamespaceURI()+'#') && node.getNamespaceURI() != null) {
-            LOGGER.info("DIFFERENT NAME SPACES: {}, {}\nNode:{}", root.getNameSpace(), node.getNamespaceURI(), node);
+            LOGGER.info("Different name spaces: {}, {}\nNode:{}", root.getNameSpace(), node.getNamespaceURI(), node);
             
-            //temp = ontology.getOntClass(node.getNamespaceURI()+'#'+ node.getLocalName());
-            //LOGGER.info("TEMP: {}", temp);
             return findResourceType(node.getNamespaceURI()+'#'+ node.getLocalName());
         } else {
             temp = (OntClass) root;

--- a/src/main/java/tr/com/srdc/ontmalizer/XSD2OWLMapper.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/XSD2OWLMapper.java
@@ -84,12 +84,11 @@ public class XSD2OWLMapper {
 
     // Variables to parse XSD schema
     private XSSchemaSet schemaSet = null;
-    //private XSSchema schema = null;
 
     // Variables to create ontology
     private OntModel ontology = null;
 
-    // To number classes named and Class_#
+    // To number classes named Class_#
     private int attrLocalSimpleTypeCount = 1;
 
     // To handle nodes with text content
@@ -101,9 +100,8 @@ public class XSD2OWLMapper {
     private ArrayList<OntClass> abstractClasses = null;
     private ArrayList<OntClass> mixedClasses = null;
 
-    //private String mainURI = null;
-    
     private XSOMParser parser;
+    // Used by XML2OWLMapper
     /*default */ Map<String, OntClass> rootTypeMap = new HashMap<>();
 
     /**
@@ -236,8 +234,6 @@ public class XSD2OWLMapper {
             parser.parse(file);
             schemaSet = parser.getResult();
             LOGGER.info("Schema size: {}, Schema Set: {}", schemaSet.getSchemaSize(), schemaSet);
-
-            //schema = schemaSet.getSchema(1);
         } catch (SAXException | IOException e) {
             LOGGER.error("{}", e.getMessage());
         }
@@ -247,12 +243,11 @@ public class XSD2OWLMapper {
         try {
             parser.parse(is);
             schemaSet = parser.getResult();
-            //schema = schemaSet.getSchema(1);
         } catch (Exception e) {
             LOGGER.error("{}", e.getMessage());
         }
     }
-    
+    // Used to customize logging for Errors    
     class MyErrorHandler implements ErrorHandler{
 
         @Override
@@ -320,10 +315,8 @@ public class XSD2OWLMapper {
             if ("".equals(nameSpace)) {
                 LOGGER.warn("Namespace for schema {} is empty string.", schema);
             }
-            
+
             try {
-                //URI uri = convertURNtoURI(nameSpace);
-            
                 URI uri = new URI(schema.getTargetNamespace());
                 if (uri.isAbsolute()) {
                     mainURI = uri.toString();
@@ -735,7 +728,6 @@ public class XSD2OWLMapper {
 				 * I added the allowed restrictions by getDeclaredAttributeUses below
              */ {
                 ontology.createClass(baseURI);
-                //LOGGER.debug("Adding superclass: {}", superClass);
                 complexClass.addSuperClass(ontology.createClass(baseURI));
             }
 
@@ -751,7 +743,6 @@ public class XSD2OWLMapper {
             XSAttGroupDecl attGroup = (XSAttGroupDecl) attGroups
                     .next();
             OntClass attgClass = ontology.createClass(getURI(mainURI, attGroup));
-            //LOGGER.debug("Adding attgClass as superclass: {}", attgClass);
             attgClass.addSubClass(complexClass);
         }
 
@@ -767,17 +758,7 @@ public class XSD2OWLMapper {
         return complexClass;
     }
     
-    public static boolean isQualified(XSElementDecl element){
-        Boolean qualified = element.getForm();
-        if (qualified == null) {
-            return false;
-        }
-        return qualified;
-    }
-
     private void convertElement(String mainURI, XSElementDecl element, OntClass parent) {
-        //LOGGER.debug("Element. element={}, parent={}", element, parent);
-        boolean qualified = isQualified(element);
         XSType elementType = element.getType();
         String URI;
         if (parent != null) {
@@ -906,10 +887,8 @@ public class XSD2OWLMapper {
                     }
                 } else if (element.getType().isComplexType()) {
                     prop = ontology.createObjectProperty(mainURI + "#" + NamingUtil.createPropertyName(opprefix, element.getName()));
-                    //LOGGER.trace("Property: {}", prop);
                     // TODO: Mustafa: How will this be possible?
                     if (element.getType().getTargetNamespace().equals(XSDDatatype.XSD)) {
-                        //LOGGER.trace("data type");
                         if (element.getType().getName().equals("anyType")) {
                             parent.addSuperClass(ontology.createAllValuesFromRestriction(null,
                                     prop,
@@ -937,12 +916,6 @@ public class XSD2OWLMapper {
                         parent.addSuperClass(ontology.createAllValuesFromRestriction(null,
                                 prop, resource));
                     } else if (element.getType().isLocal()) {
-//                        OntClass elementTypeClass = ontology.createClass(parentURI + "_complexType_"
-//
-//                                //use the hash of the schema to avoid Anon collisions between different schemas with the same target or imported namespace
-////                                + schemaHash //TODO add the schema hash somewhere else
-//                                + "_"
-//                                + anonCount++);
                         OntClass elementTypeClass = null;
                         if (element.getType().isSimpleType()) {
                             elementTypeClass = convertSimpleType(mainURI, element.getType().asSimpleType(), parentURI, element.getName());
@@ -950,7 +923,6 @@ public class XSD2OWLMapper {
                             elementTypeClass = convertComplexType(mainURI, element.getType().asComplexType(), parentURI, element.getName());
                         }
                     LOGGER.debug("Adding class for element in group: {}", elementTypeClass);
-//                    elementTypeClass.addSuperClass(ontology.createClass(mainURI + "#" + "Anon"));
                     parent.addSuperClass(ontology.createAllValuesFromRestriction(null,
                             prop, elementTypeClass));
                     }
@@ -1183,9 +1155,6 @@ public class XSD2OWLMapper {
         }
         // mainURI contains at most one '#'
         assert(mainURI.split("#").length <3);
-//        if (mainURI.contains("#")) {
-//            mainURI = mainURI.substring(0, mainURI.indexOf('#'));
-//        }
         mainURI = mainURI.replaceFirst("#", "/");
         return mainURI + "#" + decl.getName();
     }

--- a/src/main/java/tr/com/srdc/ontmalizer/data/TypedResource.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/data/TypedResource.java
@@ -3,6 +3,7 @@
  */
 package tr.com.srdc.ontmalizer.data;
 
+import org.apache.jena.ontology.OntProperty;
 import org.apache.jena.rdf.model.Resource;
 
 /**
@@ -13,6 +14,9 @@ public class TypedResource {
 
     private boolean isDatatype;
     private Resource resource;
+    
+    // used to hold on to the property we get from the ontology when determining the resource's type
+    private OntProperty property;
 
     public TypedResource() {
     }
@@ -48,6 +52,21 @@ public class TypedResource {
      */
     public void setResource(Resource resource) {
         this.resource = resource;
+    }
+
+    /**
+     * @return the property that links to this resource (may be null)
+     */
+    public OntProperty getProperty() {
+        return property;
+    }
+    
+    /**
+     * @param the property that links to this resource
+     */
+    public void setProperty(OntProperty avfrOnProp) {
+        this.property = avfrOnProp;
+        
     }
 
 }

--- a/src/main/java/tr/com/srdc/ontmalizer/helper/Constants.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/helper/Constants.java
@@ -27,6 +27,8 @@ public class Constants {
 	public static final String RDFS_TYPE_URI = "http://www.w3.org/2000/01/rdf-schema#Datatype";
 	public static final String OWL_CLASS_URI = "http://www.w3.org/2002/07/owl#Class";
 	
+	public static final String RDF_VALUE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
+	
 	public static String ONTMALIZER_VALUE_PROP_NAME;
 	public static String ONTMALIZER_ENUMERATION_CLASS_NAME;
 	public static String ONTMALIZER_ENUMERATEDVALUE_CLASS_NAME;

--- a/src/main/java/tr/com/srdc/ontmalizer/helper/XSDUtil.java
+++ b/src/main/java/tr/com/srdc/ontmalizer/helper/XSDUtil.java
@@ -5,6 +5,7 @@ package tr.com.srdc.ontmalizer.helper;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.XSD;
 
 /**
@@ -101,6 +102,9 @@ public class XSDUtil {
                 return XSD.xshort;
             case "string":
                 return XSD.xstring;
+            case "anyType":
+            case "anySimpleType":
+                return OWL.Thing;
             default:
                 break;
         }

--- a/src/test/java/tr/com/srdc/ontmalizer/test/XML2OWLTest.java
+++ b/src/test/java/tr/com/srdc/ontmalizer/test/XML2OWLTest.java
@@ -7,6 +7,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.Writer;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,6 +123,7 @@ public class XML2OWLTest {
         XML2OWLMapper generator = new XML2OWLMapper(new File("src/test/resources/salus-common-xsd/salus-eligibility-instance.xml"), mapping);
         generator.convertXML2OWL();
 
+        LOGGER.info("Converted XML 2 OWL");
         // This part prints the RDF data model to the specified file.
         try {
             File f = new File("src/test/resources/output/salus-eligibility-instance.n3");

--- a/src/test/java/tr/com/srdc/ontmalizer/test/XSD2OWLTest.java
+++ b/src/test/java/tr/com/srdc/ontmalizer/test/XSD2OWLTest.java
@@ -7,6 +7,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.Writer;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
@mbeckerle and I updated Ontmalizer to make RDF types from XSD structure instead of Anonymous types. 

This results in instance data along the lines of: 
:INS2925528_Aircraft.complexType_6
        a                       <http://com.bbn.lwap/AircraftTypeInfo/AircraftTypeInfo.complexType#Aircraft.complexType> ;

instead of: 
:INS2925528_Anon_6
        a                      Anon_6 ;

for the following partial schema: 
```
<xs:schema targetNamespace="http://com.bbn.lwap" elementFormDefault="unqualified">
    <xs:element name="AircraftTypeInfo">
        <xs:complexType>
             <xs:sequence>
                 <xs:element name="Aircraft" maxOccurs="unbounded">
                     <xs:complexType>
                     ...
                     </xs:complexType>
                 </xs:element>
            </xs:sequence>
        </xs:complexType>
    </xs:element>
</xs:schema>
```

